### PR TITLE
Fix illegal option error

### DIFF
--- a/persistent/nginx/docker-entrypoint.d/10-default-ots.envsh
+++ b/persistent/nginx/docker-entrypoint.d/10-default-ots.envsh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -eu
+set -e
 
 export WEBUI_ADDRESS=${OTS_WEBUI_ADDRESS:-'opentakserver-webui'}
 export OTS_ADDRESS=${OTS_ADDRESS:-'opentakserver:8081'}


### PR DESCRIPTION
This fixes an issue, where the project is not starting with the following error
```
/docker-entrypoint.sh: 2: set: Illegal option -
```
